### PR TITLE
feat(goals): ✨ add "Immature Progeny" to goal tracker with preview image tooltip

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -47,17 +47,20 @@ export type FeaturedGoalProgress = {
         name: string;
         maleParentName: string;
         maleParentCode: string;
-        maleParentImageUrl: string;
+        maleParentImageUrl: string | null;
+        maleParentUpdatedAt: string | null;
         femaleParentName: string;
         femaleParentCode: string;
-        femaleParentImageUrl: string;
+        femaleParentImageUrl: string | null;
+        femaleParentUpdatedAt: string | null;
         score: number;
     } | null;
     progenyCount: number;
     closestProgeny: {
         name: string;
         code: string;
-        imageUrl: string;
+        imageUrl: string | null;
+        updatedAt: string | null;
         accuracy: number;
     } | null;
 };
@@ -365,6 +368,7 @@ async function fetchUserProfile(username: string, sessionUserId?: string | null)
                     name: closest.progeny.creatureName || 'Unnamed',
                     code: closest.progeny.code,
                     imageUrl: closest.progeny.imageUrl,
+                    updatedAt: closest.progeny.updatedAt?.toISOString() ?? null,
                     accuracy: closest.accuracy,
                 };
             }
@@ -378,10 +382,14 @@ async function fetchUserProfile(username: string, sessionUserId?: string | null)
                       maleParentName: highestScoringPair.pair.maleParent!.creatureName || 'Unnamed',
                       maleParentCode: highestScoringPair.pair.maleParent!.code,
                       maleParentImageUrl: highestScoringPair.pair.maleParent!.imageUrl,
+                      maleParentUpdatedAt:
+                          highestScoringPair.pair.maleParent!.updatedAt?.toISOString() ?? null,
                       femaleParentName:
                           highestScoringPair.pair.femaleParent!.creatureName || 'Unnamed',
                       femaleParentCode: highestScoringPair.pair.femaleParent!.code,
                       femaleParentImageUrl: highestScoringPair.pair.femaleParent!.imageUrl,
+                      femaleParentUpdatedAt:
+                          highestScoringPair.pair.femaleParent!.updatedAt?.toISOString() ?? null,
                       score: highestScoringPair.score,
                   }
                 : null,

--- a/components/custom-cards/featured-goal-card.tsx
+++ b/components/custom-cards/featured-goal-card.tsx
@@ -4,74 +4,7 @@ import type { EnrichedResearchGoal, DbCreature } from '@/types';
 import type { FeaturedGoalProgress } from '@/app/[username]/page';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Award, ChevronUp, ChevronDown, ExternalLink } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-
-function ResponsiveCreatureLink({
-    displayText,
-    code,
-    imageUrl,
-    className,
-}: {
-    displayText: string;
-    code: string;
-    imageUrl: string;
-    className?: string;
-}) {
-    return (
-        <>
-            {/* Desktop: Tooltip on a link */}
-            <span className={`hidden md:inline ${className}`}>
-                <TooltipProvider>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Link
-                                href={`https://finaloutpost.net/view/${code}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline hover:text-pompaca-purple dark:hover:text-purple-300"
-                            >
-                                {displayText}
-                            </Link>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            <img
-                                src={imageUrl}
-                                alt={displayText}
-                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
-                            />
-                        </TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
-            </span>
-            {/* Mobile: Popover */}
-            <span className={`inline md:hidden ${className}`}>
-                <Popover>
-                    <PopoverTrigger asChild>
-                        <span className="underline cursor-pointer">{displayText}</span>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-2">
-                        <div className="flex flex-col gap-2 items-center">
-                            <img
-                                src={imageUrl}
-                                alt={displayText}
-                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
-                            />
-                            <Link
-                                href={`https://finaloutpost.net/view/${code}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="flex items-center gap-1 text-sm underline"
-                            >
-                                View on TFO <ExternalLink className="h-4 w-4" />
-                            </Link>
-                        </div>
-                    </PopoverContent>
-                </Popover>
-            </span>
-        </>
-    );
-}
+import { ResponsiveCreatureLink } from '../misc-custom-components/responsive-creature-link';
 
 interface FeaturedGoalCardProps {
     goal: EnrichedResearchGoal;
@@ -143,6 +76,7 @@ export function FeaturedGoalCard({ goal, achievement, username, progress }: Feat
                                     }
                                     code={achievement.creature.code}
                                     imageUrl={achievement.creature.imageUrl}
+                                    updatedAt={achievement.creature.updatedAt}
                                 />
                                 !
                             </p>
@@ -168,6 +102,9 @@ export function FeaturedGoalCard({ goal, achievement, username, progress }: Feat
                                                 imageUrl={
                                                     progress.highestScoringPair.maleParentImageUrl
                                                 }
+                                                updatedAt={
+                                                    progress.highestScoringPair.maleParentUpdatedAt
+                                                }
                                             />
                                             [{progress.highestScoringPair.maleParentCode}] x{' '}
                                             <ResponsiveCreatureLink
@@ -177,6 +114,10 @@ export function FeaturedGoalCard({ goal, achievement, username, progress }: Feat
                                                 code={progress.highestScoringPair.femaleParentCode}
                                                 imageUrl={
                                                     progress.highestScoringPair.femaleParentImageUrl
+                                                }
+                                                updatedAt={
+                                                    progress.highestScoringPair
+                                                        .femaleParentUpdatedAt
                                                 }
                                             />
                                             [{progress.highestScoringPair.femaleParentCode}]
@@ -193,6 +134,7 @@ export function FeaturedGoalCard({ goal, achievement, username, progress }: Feat
                                             displayText={`${progress.closestProgeny.name} (${progress.closestProgeny.code})`}
                                             code={progress.closestProgeny.code}
                                             imageUrl={progress.closestProgeny.imageUrl}
+                                            updatedAt={progress.closestProgeny.updatedAt}
                                         />{' '}
                                         ({(progress.closestProgeny.accuracy * 100).toFixed(2)}%
                                         accuracy)

--- a/components/custom-cards/responsive-creature-link.tsx
+++ b/components/custom-cards/responsive-creature-link.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { ExternalLink } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+function getCacheBustedImageUrl(imageUrl: string | null, updatedAt?: string | Date | null) {
+    if (!imageUrl) {
+        return '/images/misc/placeholder.png';
+    }
+    if (updatedAt) {
+        return `${imageUrl}?v=${new Date(updatedAt).getTime()}`;
+    }
+    return imageUrl;
+}
+
+export function ResponsiveCreatureLink({
+    displayText,
+    code,
+    imageUrl,
+    updatedAt,
+    className,
+}: {
+    displayText: string;
+    code: string;
+    imageUrl: string | null;
+    updatedAt?: string | Date | null;
+    className?: string;
+}) {
+    const finalImageUrl = getCacheBustedImageUrl(imageUrl, updatedAt);
+
+    return (
+        <>
+            {/* Desktop: Tooltip on a link */}
+            <span className={`hidden md:inline ${className}`}>
+                <TooltipProvider>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Link
+                                href={`https://finaloutpost.net/view/${code}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline hover:text-pompaca-purple dark:hover:text-purple-300"
+                            >
+                                {displayText}
+                            </Link>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <img
+                                src={finalImageUrl}
+                                alt={displayText}
+                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
+                            />
+                        </TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            </span>
+            {/* Mobile: Popover */}
+            <span className={`inline md:hidden ${className}`}>
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <span className="underline cursor-pointer">{displayText}</span>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-2">
+                        <div className="flex flex-col gap-2 items-center">
+                            <img
+                                src={finalImageUrl}
+                                alt={displayText}
+                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
+                            />
+                            <Link
+                                href={`https://finaloutpost.net/view/${code}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-1 text-sm underline"
+                            >
+                                View on TFO <ExternalLink className="h-4 w-4" />
+                            </Link>
+                        </div>
+                    </PopoverContent>
+                </Popover>
+            </span>
+        </>
+    );
+}

--- a/components/misc-custom-components/responsive-creature-link.tsx
+++ b/components/misc-custom-components/responsive-creature-link.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { ExternalLink } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+function getCacheBustedImageUrl(imageUrl: string | null, updatedAt?: string | Date | null) {
+    if (!imageUrl) {
+        return '/images/misc/placeholder.png';
+    }
+    if (updatedAt) {
+        return `${imageUrl}?v=${new Date(updatedAt).getTime()}`;
+    }
+    return imageUrl;
+}
+
+export function ResponsiveCreatureLink({
+    displayText,
+    code,
+    imageUrl,
+    updatedAt,
+    className,
+}: {
+    displayText: string;
+    code: string;
+    imageUrl: string | null;
+    updatedAt?: string | Date | null;
+    className?: string;
+}) {
+    const finalImageUrl = getCacheBustedImageUrl(imageUrl, updatedAt);
+
+    return (
+        <>
+            {/* Desktop: Tooltip on a link */}
+            <span className={`hidden md:inline ${className}`}>
+                <TooltipProvider>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Link
+                                href={`https://finaloutpost.net/view/${code}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline hover:text-pompaca-purple dark:hover:text-purple-300"
+                            >
+                                {displayText}
+                            </Link>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <img
+                                src={finalImageUrl}
+                                alt={displayText}
+                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
+                            />
+                        </TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            </span>
+            {/* Mobile: Popover */}
+            <span className={`inline md:hidden ${className}`}>
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <span className="underline cursor-pointer">{displayText}</span>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-2">
+                        <div className="flex flex-col gap-2 items-center">
+                            <img
+                                src={finalImageUrl}
+                                alt={displayText}
+                                className="w-24 h-24 object-contain rounded-md bg-white/10 p-1"
+                            />
+                            <Link
+                                href={`https://finaloutpost.net/view/${code}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-1 text-sm underline"
+                            >
+                                View on TFO <ExternalLink className="h-4 w-4" />
+                            </Link>
+                        </div>
+                    </PopoverContent>
+                </Popover>
+            </span>
+        </>
+    );
+}


### PR DESCRIPTION
- add Immature Progeny section to Goal Tracker that shows progeny of assigned breeding pairs that are not adults yet (no genetics to analyze) with a mouseover on desktop/popup with link on mobile.

- moved responsive creature popup component to its own file