### PR TITLE
DX: schema: constrain report status

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -364,6 +364,10 @@ export const reports = pgTable('report', {
         .notNull()
         .references(() => users.id, { onDelete: 'cascade' }),
     reason: text('reason').notNull(),
-    status: text('status').default('open').notNull(), // e.g., 'open', 'resolved', 'dismissed'
+    status: text('status', {
+        enum: ['open', 'resolved', 'dismissed'],
+    })
+        .default('open')
+        .notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
 });


### PR DESCRIPTION
This change simply brings more accurate typing to the status field on the report table. It's only ever one of three values, so it makes sense to tell typescript it's a union of those.