### PR TITLE
feat(collection): 🚸 add generation update to activity log, tiny ui fix

### DIFF
--- a/components/custom-cards/creature-card.tsx
+++ b/components/custom-cards/creature-card.tsx
@@ -439,7 +439,7 @@ export function CreatureCard({
                             )}
                             <span>
                                 {' (G'}
-                                {generation}
+                                {creature.generation}
                                 {!isAdminView && (
                                     <SetGenerationDialog creature={creature}>
                                         <Button


### PR DESCRIPTION
generation and origin update now shows up in activity log, creature card displays correct gen when manually updated