### PR TITLE
fix(collection): 🐛 allow "another lab" to be set for non G1 creatures, display both pair and 'another lab' if needed

### DIFF
--- a/app/api/creatures/[creatureId]/generation/route.ts
+++ b/app/api/creatures/[creatureId]/generation/route.ts
@@ -29,9 +29,9 @@ export async function PATCH(request: Request, { params }: { params: { creatureId
 
         const { generation, g1Origin } = validation.data;
 
-        if (generation !== 1 && g1Origin) {
+        if (generation !== 1 && g1Origin && g1Origin !== 'another-lab') {
             return NextResponse.json(
-                { error: 'G1 Origin can only be set for G1 creatures.' },
+                { error: 'Only "Another Lab" origin can be set for non-G1 creatures.' },
                 { status: 400 }
             );
         }
@@ -40,7 +40,7 @@ export async function PATCH(request: Request, { params }: { params: { creatureId
             .update(creatures)
             .set({
                 generation,
-                g1Origin: generation === 1 ? g1Origin : null, // Clear origin if not G1
+                g1Origin: generation === 1 || g1Origin === 'another-lab' ? g1Origin : null,
             })
             .where(and(eq(creatures.id, creatureId), eq(creatures.userId, userId)))
             .returning();

--- a/components/custom-cards/creature-card.tsx
+++ b/components/custom-cards/creature-card.tsx
@@ -306,7 +306,7 @@ export function CreatureCard({
                     {!isAdminView && (
                         <div className="text-sm">
                             <strong>Parents/Origin:</strong>{' '}
-                            {parentPair ? (
+                            {parentPair && (
                                 <Dialog>
                                     <TooltipProvider>
                                         <Tooltip>
@@ -424,14 +424,12 @@ export function CreatureCard({
                                         />
                                     </DialogContent>
                                 </Dialog>
-                            ) : (
-                                <>
-                                    {creature.g1Origin === 'cupboard' && 'Cupboard'}
-                                    {creature.g1Origin === 'genome-splicer' && 'Genome Splicer'}
-                                    {creature.g1Origin === 'another-lab' && 'Another Lab'}
-                                    {!creature.g1Origin && 'Unknown'}
-                                </>
                             )}
+                            {parentPair && creature.g1Origin === 'another-lab' && (
+                                <span>{' / '}</span>
+                            )}
+                            {creature.g1Origin === 'another-lab' && <span>{'Another Lab'}</span>}
+                            {!parentPair && !creature.g1Origin && 'Unknown'}
                             <span>
                                 {' (G'}
                                 {creature.generation}

--- a/components/custom-dialogs/set-generation-dialog.tsx
+++ b/components/custom-dialogs/set-generation-dialog.tsx
@@ -37,11 +37,15 @@ export function SetGenerationDialog({ creature, children }: SetGenerationDialogP
 
     const isG1 = generation === 1 || generation === '1';
 
+    const handleGenerationChange = (value: string) => {
+        setGeneration(value ? Number(value) : '');
+    };
+
     const handleSave = async () => {
         setIsLoading(true);
 
         const generationValue = generation === '' ? null : Number(generation);
-        const originValue = isG1 && g1Origin !== 'none' ? g1Origin : null;
+        const originValue = g1Origin !== 'none' ? g1Origin : null;
 
         try {
             const response = await fetch(`/api/creatures/${creature?.id}/generation`, {
@@ -84,29 +88,36 @@ export function SetGenerationDialog({ creature, children }: SetGenerationDialogP
                             type="number"
                             min="1"
                             value={generation}
-                            onChange={(e) =>
-                                setGeneration(e.target.value ? Number(e.target.value) : '')
-                            }
+                            onChange={(e) => handleGenerationChange(e.target.value)}
                             className="min-w-0 max-w-15 text-left bg-ebena-lavender dark:text-barely-lilac dark:bg-midnight-purple"
                         />
 
                         <Label htmlFor="g1-origin" className="text-left">
                             Origin if G1:
                         </Label>
-                        <Select value={g1Origin} onValueChange={setG1Origin} disabled={!isG1}>
+                        <Select
+                            value={g1Origin}
+                            onValueChange={(value) => {
+                                setG1Origin(value);
+                            }}
+                        >
                             <SelectTrigger className="bg-ebena-lavender dark:text-barely-lilac dark:bg-midnight-purple">
                                 <SelectValue placeholder="Select origin..." />
                             </SelectTrigger>
                             <SelectContent className="bg-ebena-lavender dark:text-barely-lilac dark:bg-midnight-purple">
                                 <SelectItem value="none">None</SelectItem>
-                                <SelectItem value="cupboard">Cupboard</SelectItem>
-                                <SelectItem value="genome-splicer">Genome Splicer</SelectItem>
+                                <SelectItem value="cupboard" disabled={!isG1}>
+                                    Cupboard
+                                </SelectItem>
+                                <SelectItem value="genome-splicer" disabled={!isG1}>
+                                    Genome Splicer
+                                </SelectItem>
                                 <SelectItem value="another-lab">Another Lab</SelectItem>
                             </SelectContent>
                         </Select>
                     </div>
                     <p className="text-xs text-dusk-purple dark:text-purple-400 col-span-4 py-5">
-                        Origin can only be set if Generation is 1.
+                        Origins other than "Another Lab" can only be set if Generation is 1.
                     </p>
                 </div>
                 <div className="flex justify-end gap-2">


### PR DESCRIPTION
- update API to accept "another-lab" for non G1s
- update creature card to display both parent pair and "another lab" if indicated
- update set generation dialog to allow "another lab" selection for non-G1s