### PR TITLE
fix(collection): 🐛 add 'unknown' and 'bred' origins, update database and filters, fix #277

### DIFF
--- a/app/api/breeding-log/route.ts
+++ b/app/api/breeding-log/route.ts
@@ -192,7 +192,7 @@ export async function POST(req: Request) {
                 const generation = calculateGeneration(progenyId, allUserPairs, allUserLogs);
                 await db
                     .update(creatures)
-                    .set({ generation })
+                    .set({ generation, origin: 'bred' })
                     .where(and(eq(creatures.id, progenyId), eq(creatures.userId, userId)));
             }
         }
@@ -302,7 +302,7 @@ export async function PUT(req: Request) {
                     const generation = calculateGeneration(progenyId, allUserPairs, allUserLogs);
                     await db
                         .update(creatures)
-                        .set({ generation })
+                        .set({ generation, origin: 'bred' })
                         .where(and(eq(creatures.id, progenyId), eq(creatures.userId, userId)));
                 }
             }
@@ -547,7 +547,7 @@ export async function PATCH(req: Request) {
 
             await tx
                 .update(creatures)
-                .set({ generation })
+                .set({ generation, origin: 'bred' })
                 .where(and(eq(creatures.id, progenyId), eq(creatures.userId, userId)));
 
             const destinationPair = await db.query.breedingPairs.findFirst({

--- a/app/api/breeding-predictions/route.ts
+++ b/app/api/breeding-predictions/route.ts
@@ -31,7 +31,7 @@ const enrichAndSerializeCreature = (creature: DbCreature): EnrichedCreature | nu
         createdAt: creature.createdAt.toISOString(),
         updatedAt: creature.updatedAt.toISOString(),
         gottenAt: creature.gottenAt ? creature.gottenAt.toISOString() : null,
-        g1_origin: creature.g1Origin,
+        origin: creature.origin,
         geneData:
             creature.genetics
                 ?.split(',')

--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -27,7 +27,7 @@ export default async function CollectionPage({
         species?: string;
         showArchived?: string;
         generation?: string;
-        g1Origin?: string;
+        origin?: string;
         geneCategory?: string;
         geneQuery?: string;
         geneMode?: 'phenotype' | 'genotype';
@@ -42,7 +42,7 @@ export default async function CollectionPage({
         species: searchParams?.species,
         showArchived: searchParams?.showArchived,
         generation: searchParams?.generation,
-        g1Origin: searchParams?.g1Origin,
+        origin: searchParams?.origin,
         geneCategory: searchParams?.geneCategory,
         geneQuery: searchParams?.geneQuery,
         geneMode: searchParams?.geneMode,

--- a/components/custom-cards/creature-card.tsx
+++ b/components/custom-cards/creature-card.tsx
@@ -448,19 +448,18 @@ export function CreatureCard({
                                         </DialogContent>
                                     </Dialog>
                                 )}
-                                {parentPair && creature.g1Origin === 'another-lab' && (
-                                    <span>{' / '}</span>  
+                                {parentPair && creature.origin === 'another-lab' && (
+                                    <span>{' / '}</span>
                                 )}
-                                {creature.g1Origin === 'another-lab' && (
-                                    <span>{'Another Lab'}</span>
-                                )}
-                                {creature.g1Origin === 'cupboard' && <span>{'Cupboard'}</span>}
-                                {creature.g1Origin === 'quest' && <span>{'Quest'}</span>}
-                                {creature.g1Origin === 'raffle' && <span>{'Raffle'}</span>}
-                                {creature.g1Origin === 'genome-splicer' && (
+                                {creature.origin === 'unknown' && <span>{'Unknown'}</span>}
+                                {creature.origin === 'another-lab' && <span>{'Another Lab'}</span>}
+                                {creature.origin === 'cupboard' && <span>{'Cupboard'}</span>}
+                                {creature.origin === 'quest' && <span>{'Quest'}</span>}
+                                {creature.origin === 'raffle' && <span>{'Raffle'}</span>}
+                                {creature.origin === 'genome-splicer' && (
                                     <span>{'Genome Splicer'}</span>
                                 )}
-                                {!parentPair && !creature.g1Origin && 'Unknown'}
+                                {!parentPair && !creature.origin && 'Unknown'}
                                 <span>
                                     {' (G'}
                                     {creature.generation}

--- a/components/custom-clients/collection-client.tsx
+++ b/components/custom-clients/collection-client.tsx
@@ -66,7 +66,7 @@ type CollectionClientProps = {
     currentUser?: User | null;
     searchParams?: {
         generation?: string;
-        g1Origin?: string;
+        origin?: string;
         geneCategory?: string;
         geneQuery?: string;
         page?: string;
@@ -326,8 +326,16 @@ export function CollectionClient({
     const currentQuery = searchParamsFromProps?.query || '';
     const showArchived = searchParamsFromProps?.showArchived === 'true';
     const currentGeneration = searchParamsFromProps?.generation || '';
-    const currentG1Origin = searchParamsFromProps?.g1Origin || 'all';
-    const g1Origins = ['cupboard', 'genome-splicer', 'another-lab', 'quest', 'raffle'];
+    const currentorigin = searchParamsFromProps?.origin || 'all';
+    const origins = [
+        'bred',
+        'unknown',
+        'cupboard',
+        'genome-splicer',
+        'another-lab',
+        'quest',
+        'raffle',
+    ];
 
     return (
         <div className="min-h-screen">
@@ -395,17 +403,19 @@ export function CollectionClient({
                         />
 
                         <select.Select
-                            value={currentG1Origin}
-                            onValueChange={(value) => handleFilterChange('g1Origin', value)}
+                            value={currentorigin}
+                            onValueChange={(value) => handleFilterChange('origin', value)}
                         >
                             <select.SelectTrigger className="w-full bg-ebena-lavender dark:bg-midnight-purple text-pompaca-purple dark:text-purple-300 border-pompaca-purple dark:border-purple-400 drop-shadow-sm drop-shadow-gray-500 focus-visible:ring-0">
-                                <select.SelectValue placeholder="G1 Origin" />
+                                <select.SelectValue placeholder="Origin" />
                             </select.SelectTrigger>
                             <select.SelectContent className="bg-ebena-lavender dark:bg-midnight-purple text-pompaca-purple dark:text-purple-300">
                                 <select.SelectItem value="all">All Origins</select.SelectItem>
-                                {g1Origins.map((origin) => (
+                                {origins.map((origin) => (
                                     <select.SelectItem key={origin} value={origin}>
-                                        {origin.charAt(0).toUpperCase() + origin.slice(1)}
+                                        {origin
+                                            .replace(/-/g, ' ')
+                                            .replace(/\b\w/g, (l) => l.toUpperCase())}
                                     </select.SelectItem>
                                 ))}
                             </select.SelectContent>

--- a/components/custom-dialogs/set-generation-dialog.tsx
+++ b/components/custom-dialogs/set-generation-dialog.tsx
@@ -34,15 +34,15 @@ export function SetGenerationDialog({ creature, children }: SetGenerationDialogP
     const [isOpen, setIsOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [generation, setGeneration] = useState<number | string>(creature?.generation ?? 1);
-    const [g1Origin, setG1Origin] = useState(creature?.g1Origin || 'none');
+    const [origin, setorigin] = useState(creature?.origin || 'none');
 
     const isG1 = generation === 1 || generation === '1';
 
     const handleGenerationChange = (value: string) => {
         setGeneration(value ? Number(value) : '');
         const newIsG1 = value === '1';
-        if (!newIsG1 && g1Origin !== 'another-lab') {
-            setG1Origin('none');
+        if (!newIsG1 && origin !== 'another-lab') {
+            setorigin('none');
         }
     };
 
@@ -50,13 +50,13 @@ export function SetGenerationDialog({ creature, children }: SetGenerationDialogP
         setIsLoading(true);
 
         const generationValue = generation === '' ? null : Number(generation);
-        const originValue = g1Origin !== 'none' ? g1Origin : null;
+        const originValue = origin !== 'none' ? origin : null;
 
         try {
             const response = await fetch(`/api/creatures/${creature?.id}/generation`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ generation: generationValue, g1Origin: originValue }),
+                body: JSON.stringify({ generation: generationValue, origin: originValue }),
             });
 
             if (!response.ok) {
@@ -101,16 +101,16 @@ export function SetGenerationDialog({ creature, children }: SetGenerationDialogP
                             Origin:
                         </Label>
                         <Select
-                            value={g1Origin}
+                            value={origin}
                             onValueChange={(value) => {
-                                setG1Origin(value as any);
+                                setorigin(value as any);
                             }}
                         >
                             <SelectTrigger className="bg-ebena-lavender dark:text-barely-lilac dark:bg-midnight-purple">
                                 <SelectValue placeholder="Select origin..." />
                             </SelectTrigger>
                             <SelectContent className="bg-ebena-lavender dark:text-barely-lilac dark:bg-midnight-purple">
-                                <SelectItem value="none">None</SelectItem>
+                                <SelectItem value="unknown">Unknown</SelectItem>
                                 <SelectItem value="cupboard" disabled={!isG1}>
                                     Cupboard
                                 </SelectItem>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -288,7 +288,7 @@ export async function fetchFilteredCreatures(
         species?: string;
         showArchived?: string;
         generation?: string;
-        g1Origin?: string;
+        origin?: string;
         geneCategory?: string;
         geneQuery?: string;
         geneMode?: 'phenotype' | 'genotype';
@@ -305,7 +305,7 @@ export async function fetchFilteredCreatures(
         species,
         showArchived,
         generation,
-        g1Origin,
+        origin,
         geneCategory,
         geneQuery,
         geneMode = 'phenotype', // Default to phenotype if not provided
@@ -355,14 +355,14 @@ export async function fetchFilteredCreatures(
                   ilike(creatures.code, `%${query}%`),
                   ilike(creatures.creatureName, `%${query}%`),
                   ilike(creatures.genetics, `%${query}%`),
-                  ilike(creatures.g1Origin, `%${query}%`)
+                  ilike(creatures.origin, `%${query}%`)
               )
             : undefined,
         gender && gender !== 'all' ? eq(creatures.gender, gender as any) : undefined,
         growthLevel ? eq(creatures.growthLevel, growthLevel) : undefined,
         species && species !== 'all' ? ilike(creatures.species, species) : undefined,
         generation ? eq(creatures.generation, Number(generation)) : undefined,
-        g1Origin && g1Origin !== 'all' ? eq(creatures.g1Origin, g1Origin as any) : undefined,
+        origin && origin !== 'all' ? eq(creatures.origin, origin as any) : undefined,
     ].filter(Boolean);
 
     if (geneQuery && geneCategory && geneString.length > 0) {

--- a/lib/serialization.ts
+++ b/lib/serialization.ts
@@ -11,7 +11,7 @@ export const enrichAndSerializeCreature = (creature: DbCreature | null): Enriche
         updatedAt: creature.updatedAt.toISOString(),
         gottenAt: creature.gottenAt ? creature.gottenAt.toISOString() : null,
         generation: creature.generation,
-        g1_origin: creature.g1Origin,
+        origin: creature.origin,
         geneData:
             creature.genetics
                 ?.split(',')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tfo-creaturetracker",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "scripts": {
         "reset": "rm -rf .next node_modules package-lock.json pnpm-lock.yaml && pnpm store prune && pnpm i && pnpm dev",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -171,8 +171,16 @@ export const pendingRegistrations = pgTable('pending_registration', {
     expiresAt: timestamp('expires_at', { mode: 'date' }).notNull(),
 });
 
-// Creature Functionality
 export const creatureGenderEnum = pgEnum('gender', ['male', 'female', 'genderless', 'unknown']);
+export const creatureOriginEnum = pgEnum('origin', [
+    'cupboard',
+    'genome-splicer',
+    'another-lab',
+    'quest',
+    'raffle',
+    'unknown',
+    'bred',
+]);
 
 export const creatures = pgTable(
     'creature',
@@ -196,9 +204,7 @@ export const creatures = pgTable(
         pinOrder: integer('pin_order'),
         isArchived: boolean('is_archived').default(false).notNull(),
         generation: integer('generation').default(1).notNull(),
-        g1Origin: text('g1_origin', {
-            enum: ['cupboard', 'genome-splicer', 'another-lab', 'quest', 'raffle'],
-        }),
+        origin: creatureOriginEnum('origin').default('unknown').notNull(),
         createdAt: timestamp('created_at').defaultNow().notNull(),
         updatedAt: timestamp('updated_at').defaultNow().notNull(),
     },

--- a/types/index.ts
+++ b/types/index.ts
@@ -55,7 +55,7 @@ export type EnrichedCreature =
               phenotype: string;
           }[];
           generation: number | null;
-          g1_origin: string | null;
+          origin: string | null;
       })
     | null;
 


### PR DESCRIPTION
fix #277:
change g1_origin col in db to "origin" and add unknown and bred origins. Unknown is default, bred will be assigned to creatures with parents.
Filters now have origin and bred as option and it is filtering properly.